### PR TITLE
Update scripts that build HTML from Markdown to use stylesheets in new location

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,0 @@
-Contributing to Portal Quickstarts
-=========================================
-
-To contribute to Portal Quickstarts, take a look at the JBoss Developer Framework contributing guidelines at
-https://github.com/jboss-jdf/jboss-as-quickstart/blob/master/CONTRIBUTING.md

--- a/README.html
+++ b/README.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html><head><title>README</title><link href="https://raw.github.com/pmuir/github-flavored-markdown/gh-pages/shared/css/documentation.css" rel="stylesheet"></link><link href="https://raw.github.com/github/github-flavored-markdown/gh-pages/shared/css/pygments.css" rel="stylesheet"></link></head><body><!--~ Do not edit this derived file! See jboss-portal-quickstarts/src/main/freemarker/README.html.ftl ~-->
+<!DOCTYPE html><html><head><title>README</title><link href="http://static.jboss.org/ffe/0/www/vendor/redhat/documentation.css" rel="stylesheet"></link><link href="http://static.jboss.org/ffe/0/www/vendor/redhat/pygments.css" rel="stylesheet"></link></head><body><!--~ Do not edit this derived file! See jboss-portal-quickstarts/src/main/freemarker/README.html.ftl ~-->
 
 <h1><a id="portal-quickstarts" class="anchor" href="#portal-quickstarts"><span class="anchor-icon"></span></a>Portal Quickstarts</h1>
 
@@ -27,5 +27,11 @@ examples that can be used as a reference for your own project.</p>
 <li><a href="social-portlets/README.html">Social Portlets</a></li>
 <li><a href="portal-extension/README.html">Portal Extension</a></li>
 <li><a href="sample-portal/README.html">Sample Portal</a></li>
+</ul>
+
+<h2><a id="how-to-contribute" class="anchor" href="#how-to-contribute"><span class="anchor-icon"></span></a>How to Contribute</h2>
+
+<ul>
+<li><a href="https://github.com/jboss-developer/jboss-developer-shared-resources/blob/master/guides/CONTRIBUTING.md#jboss-developer-contributing-guide">Contributing Guide</a>: This document contains information targeted for developers who want to contribute to JBoss developer projects.</li>
 </ul>
 </body></html>

--- a/README.md
+++ b/README.md
@@ -27,3 +27,10 @@ Available Quickstarts
 * [Social Portlets](social-portlets/README.html)
 * [Portal Extension](portal-extension/README.html)
 * [Sample Portal](sample-portal/README.html)
+
+
+How to Contribute
+------------------
+
+* [Contributing Guide](https://github.com/jboss-developer/jboss-developer-shared-resources/blob/master/guides/CONTRIBUTING.md#jboss-developer-contributing-guide): This document contains information targeted for developers who want to contribute to JBoss developer projects.
+

--- a/cdi-generic-portlet/README.html
+++ b/cdi-generic-portlet/README.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html><head><title>README</title><link href="https://raw.github.com/pmuir/github-flavored-markdown/gh-pages/shared/css/documentation.css" rel="stylesheet"></link><link href="https://raw.github.com/github/github-flavored-markdown/gh-pages/shared/css/pygments.css" rel="stylesheet"></link></head><body><!--~ Do not edit this derived file! See jboss-portal-quickstarts/src/main/freemarker/cdi-generic-portlet/README.html.ftl ~-->
+<!DOCTYPE html><html><head><title>README</title><link href="http://static.jboss.org/ffe/0/www/vendor/redhat/documentation.css" rel="stylesheet"></link><link href="http://static.jboss.org/ffe/0/www/vendor/redhat/pygments.css" rel="stylesheet"></link></head><body><!--~ Do not edit this derived file! See jboss-portal-quickstarts/src/main/freemarker/cdi-generic-portlet/README.html.ftl ~-->
 
 <h1><a id="cdigenericportlet-cdi-generic-portlet" class="anchor" href="#cdigenericportlet-cdi-generic-portlet"><span class="anchor-icon"></span></a>cdi-generic-portlet: CDI Generic Portlet</h1>
 

--- a/cdi-jsf-portlet/README.html
+++ b/cdi-jsf-portlet/README.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html><head><title>README</title><link href="https://raw.github.com/pmuir/github-flavored-markdown/gh-pages/shared/css/documentation.css" rel="stylesheet"></link><link href="https://raw.github.com/github/github-flavored-markdown/gh-pages/shared/css/pygments.css" rel="stylesheet"></link></head><body><!--~ Do not edit this derived file! See jboss-portal-quickstarts/src/main/freemarker/cdi-jsf-portlet/README.html.ftl ~-->
+<!DOCTYPE html><html><head><title>README</title><link href="http://static.jboss.org/ffe/0/www/vendor/redhat/documentation.css" rel="stylesheet"></link><link href="http://static.jboss.org/ffe/0/www/vendor/redhat/pygments.css" rel="stylesheet"></link></head><body><!--~ Do not edit this derived file! See jboss-portal-quickstarts/src/main/freemarker/cdi-jsf-portlet/README.html.ftl ~-->
 
 <h1><a id="cdijsfportlet-cdi-portlet-with-jsf" class="anchor" href="#cdijsfportlet-cdi-portlet-with-jsf"><span class="anchor-icon"></span></a>cdi-jsf-portlet: CDI Portlet with JSF</h1>
 

--- a/cdi-scopes-portlet/README.html
+++ b/cdi-scopes-portlet/README.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html><head><title>README</title><link href="https://raw.github.com/pmuir/github-flavored-markdown/gh-pages/shared/css/documentation.css" rel="stylesheet"></link><link href="https://raw.github.com/github/github-flavored-markdown/gh-pages/shared/css/pygments.css" rel="stylesheet"></link></head><body><!--~ Do not edit this derived file! See jboss-portal-quickstarts/src/main/freemarker/cdi-scopes-portlet/README.html.ftl ~-->
+<!DOCTYPE html><html><head><title>README</title><link href="http://static.jboss.org/ffe/0/www/vendor/redhat/documentation.css" rel="stylesheet"></link><link href="http://static.jboss.org/ffe/0/www/vendor/redhat/pygments.css" rel="stylesheet"></link></head><body><!--~ Do not edit this derived file! See jboss-portal-quickstarts/src/main/freemarker/cdi-scopes-portlet/README.html.ftl ~-->
 
 <h1><a id="cdiscopesportlet-portlet-using-portetspecific-cdi-scopes" class="anchor" href="#cdiscopesportlet-portlet-using-portetspecific-cdi-scopes"><span class="anchor-icon"></span></a>cdi-scopes-portlet: Portlet Using Portet-Specific CDI Scopes</h1>
 

--- a/dist/github-flavored-markdown.rb
+++ b/dist/github-flavored-markdown.rb
@@ -1,0 +1,153 @@
+#!/usr/bin/env ruby
+#
+# JBoss, Home of Professional Open Source
+# Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+# contributors by the @authors tag. See the copyright.txt in the
+# distribution for a full listing of individual contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+require 'rubygems'
+require 'redcarpet'
+require 'nokogiri'
+require 'fileutils'
+require 'pygments.rb'
+require 'rexml/document'
+
+# create a custom renderer that allows highlighting of code blocks
+class HTMLWithPygmentsAndPants < Redcarpet::Render::HTML
+  include Redcarpet::Render::SmartyPants
+  def block_code(code, language)
+    Pygments.highlight(code, :lexer => language, :options => {:encoding => 'utf-8'})
+  end
+
+  #method copied from: https://gist.github.com/suan/5692767
+  def header(title, level)
+    @headers ||= []
+
+    title_elements = REXML::Document.new(title)
+    flattened_title = title_elements.inject('') do |flattened, element|
+      flattened +=  if element.respond_to?(:text)
+                      element.text
+                    else
+                      element.to_s
+                    end
+    end
+    permalink = flattened_title.downcase.gsub(/[^a-z0-9\s]/, '').gsub(/\W+/, "-")
+
+    # for extra credit: implement this as its own method
+    if @headers.include?(permalink)
+      permalink += "_1"
+       # my brain hurts
+      loop do
+        break if !@headers.include?(permalink)
+        # generate titles like foo-bar_1, foo-bar_2
+        permalink.gsub!(/\_(\d+)$/, "_#{$1.to_i + 1}")
+      end
+    end
+    @headers << permalink
+    %(\n<h#{level}><a id="#{permalink}" class="anchor" href="##{permalink}"><span class="anchor-icon"></span></a>#{title}</h#{level}>\n)
+  end
+end
+
+
+def find(p, tag)
+  if p.text
+    r = p.text[/^(#{tag}: )(.+)$/, 2]
+    if r
+      p['id'] = 'metadata'
+      return r 
+    end
+  end
+end
+
+def find_split(p, tag)
+  s = find(p, tag)
+  if s
+    return s.split(',').sort 
+  end
+end
+
+def metadata(source_path, html)
+  # TODO canonicalise path
+  toc_file='dist/target/toc.html'
+  # Markdown doesn't have an metadata syntax, so all we can do is pray ;-)
+  # Look for a paragraph that contains tags, which we define by convention
+  page_content = Nokogiri::HTML(html)
+  technologies = []
+  level = "" 
+  prerequisites = []
+  summary = ""
+  page_content.css('p').each do |p|
+    t = find_split(p, 'Technologies')
+    if t
+      technologies = t
+    end
+    l = find(p, 'Level')
+    if l
+      level = l
+    end
+    pr = find_split(p, 'Prerequisites')
+    if pr
+      prerequisites = pr
+    end
+    s = find(p, 'Summary')
+    if s
+      summary = s
+    end
+
+  end
+  dir = source_path[/([^\/]+)\/([^\/]+).md$/, 1]
+  filename = source_path[/([^\/]+)\/([^\/]+).md$/, 2]
+  if dir
+    output = "<tr><td align='left'><a href='#{dir}/#{filename}.md' title='#{dir}'>#{dir}</td><td align='left'>#{' '.concat(technologies.map{|u| u} * ', ')}</td><td align='left'>#{summary}</td><td align='left'>#{level}</td><td align='left'>#{' '.concat(prerequisites.map{|u| u} * ', ')}</td></tr>\n"
+    FileUtils.mkdir_p(File.dirname(toc_file))
+    File.open(toc_file, 'a').write(output)
+  end
+end
+
+def markdown(source_path)
+  renderer = HTMLWithPygmentsAndPants.new(optionize [
+    :with_toc_data,
+    :xhtml
+  ])
+  markdown = Redcarpet::Markdown.new(renderer, optionize([
+    :fenced_code_blocks,
+    :no_intra_emphasis,
+    :tables,
+    :autolink,
+    :strikethrough,
+    :space_after_headers,
+    :with_toc_data
+  ]))
+  text = source_path.read
+  toc_file='dist/target/toc.html'
+  if File.exist?(toc_file)
+    qs_toc_content=File.open('dist/target/toc.html').read
+    qs_toc = "<table><thead><tr><th align='left'><strong>Quickstart Name</strong></th><th align='left'><strong>Demonstrated Technologies</strong></th><th align='left'><strong>Description</strong></th><th align='left'><strong>Experience Level Required</strong></th><th align='left'><strong>Prerequisites</strong></th></tr></thead><tbody>#{qs_toc_content}</table></table>"
+    text.gsub!("\[TOC-quickstart\]", qs_toc)
+  end
+  toc = Redcarpet::Markdown.new(Redcarpet::Render::HTML_TOC).render(text)
+  text.gsub!("\[TOC\]", toc)
+  rendered = markdown.render(text)
+  metadata(source_path.path, rendered)
+  rendered = rendered.gsub(/README.md/, "README.html")
+  '<!DOCTYPE html><html><head><title>README</title><link href="http://static.jboss.org/ffe/0/www/vendor/redhat/documentation.css" rel="stylesheet"></link><link href="http://static.jboss.org/ffe/0/www/vendor/redhat/pygments.css" rel="stylesheet"></link></head><body>' + rendered + '</body></html>'
+  end
+
+def optionize(options)
+  options.each_with_object({}) { |option, memo| memo[option] = true }
+end
+
+puts markdown(ARGF)
+

--- a/dist/release-utils.sh
+++ b/dist/release-utils.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+#
+# JBoss, Home of Professional Open Source
+# Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+# contributors by the @authors tag. See the copyright.txt in the
+# distribution for a full listing of individual contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+REQUIRED_BASH_VERSION=3.0.0
+
+if [[ $BASH_VERSION < $REQUIRED_BASH_VERSION ]]; then
+  echo "You must use Bash version 3 or newer to run this script"
+  exit
+fi
+
+
+DIR=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+
+# DEFINE
+
+ARCHETYPES=("jboss-javaee6-webapp-archetype" "jboss-javaee6-webapp-ear-archetype")
+QUICKSTARTS=("kitchensink" "kitchensink-ear")
+VERSIONS_MAVEN_PLUGIN_VERSION=1.3.1
+
+# SCRIPT
+
+HUMAN_READABLE_ARCHETYPES=""
+i=0
+element_count=${#ARCHETYPES[@]}
+index=0
+while [ "$index" -lt "$element_count" ]
+do
+   if [ $index -ne 0 ]
+   then
+      HUMAN_READABLE_ARCHETYPES="${HUMAN_READABLE_ARCHETYPES}, "
+   fi
+   HUMAN_READABLE_ARCHETYPES="${HUMAN_READABLE_ARCHETYPES}${ARCHETYPES[index]}"
+   ((index++))
+done
+
+
+usage()
+{
+cat << EOF
+usage: $0 options
+
+This script aids in releasing the quickstarts
+
+OPTIONS:
+   -u      Updates version numbers in all POMs, used with -o and -n      
+   -o      Old version number to update from
+   -n      New version number to update to
+   -r      Regenerate the various quickstarts based on archetypes ${HUMAN_READABLE_ARCHETYPES}
+   -m      Generate html versions of markdown readmes
+   -h      Shows this message
+EOF
+}
+
+update()
+{
+    cd $DIR/../
+    echo "Updating versions from $OLDVERSION TO $NEWVERSION for all Java files under $PWD"
+    perl -pi -e "s/${OLDVERSION}/${NEWVERSION}/g" `find . -name \*.java`
+
+    echo "Performing updates to POMs"
+    poms=`find . -type f -iname "pom.xml" -maxdepth 2 | sort`
+    for pom in $poms
+    do
+        echo "Updating ${pom}"
+        mvn org.codehaus.mojo:versions-maven-plugin:${VERSIONS_MAVEN_PLUGIN_VERSION}:set -DnewVersion=${NEWVERSION} -f ${pom} -q
+        mvn org.codehaus.mojo:versions-maven-plugin:${VERSIONS_MAVEN_PLUGIN_VERSION}:commit -f ${pom} -q
+    done
+}
+
+markdown_to_html()
+{
+   cd $DIR/../
+
+   # Clear the contents from toc.html file
+   rm dist/target/toc.html
+   touch dist/target/toc.html
+
+   # Loop through the sorted quickstart directories and process them
+   # Exclude the template directory since it's not a quickstart
+   subdirs=`find . -maxdepth 1 -type d ! -iname ".*" ! -iname "template" | sort`
+   for subdir in $subdirs
+   do
+      readmes=`find $subdir -iname readme.md`
+      for readme in $readmes
+      do
+         echo "Processing $readme"
+         output_filename=${readme//.md/.html}
+         output_filename=${output_filename//.MD/.html}
+         $DIR/github-flavored-markdown.rb $readme > $output_filename  
+      done
+   done
+   # Now process the root readme
+   cd $DIR/../
+   readme=README.md
+   echo "Processing $readme"
+   output_filename=${readme//.md/.html}
+   output_filename=${output_filename//.MD/.html}
+   $DIR/github-flavored-markdown.rb $readme > $output_filename  
+}
+
+regenerate()
+{
+   TMPDIR="$DIR/target/regen"
+   ROOTDIR="$DIR/../"
+   
+   rm -rf $TMPDIR
+
+   mkdir -p $TMPDIR
+
+   cd $TMPDIR
+
+   element_count=${#ARCHETYPES[@]}
+   index=0
+   while [ "$index" -lt "$element_count" ]
+   do
+      archetype=${ARCHETYPES[index]}
+      quickstart=${QUICKSTARTS[index]}
+      package=${quickstart//-/_}
+      name="JBoss AS Quickstarts: $quickstart"
+      echo "**** Regenerating $quickstart from $archetype"
+      mvn archetype:generate -DarchetypeGroupId=org.jboss.spec.archetypes -DarchetypeArtifactId=$archetype -DarchetypeVersion=$VERSION -DartifactId=jboss-as-$quickstart -DgroupId=org.jboss.as.quickstarts -Dpackage=org.jboss.as.quickstarts.$package -Dversion=$VERSION -DinteractiveMode=false -Dname="${name}"
+      ((index++))
+      rm -rf $ROOTDIR/$quickstart
+      mv $TMPDIR/jboss-as-$quickstart $ROOTDIR/$quickstart
+   done
+
+}
+
+OLDVERSION="1.0.0-SNAPSHOT"
+NEWVERSION="1.0.0-SNAPSHOT"
+VERSION="1.0.0-SNAPSHOT"
+CMD="usage"
+
+while getopts “muo:n:r:” OPTION
+
+do
+     case $OPTION in
+         u)
+             CMD="update"
+             ;;
+         h)
+             usage
+             exit
+             ;;
+         o)
+             OLDVERSION=$OPTARG
+             ;;
+         n)
+             NEWVERSION=$OPTARG
+             ;;
+         r) 
+             CMD="regenerate"
+             VERSION=$OPTARG
+             ;;
+         m)
+             CMD="markdown_to_html"
+             ;;
+         [?])
+             usage
+             exit
+             ;;
+     esac
+done
+
+$CMD
+

--- a/jsf2-hello-world-portlet/README.html
+++ b/jsf2-hello-world-portlet/README.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html><head><title>README</title><link href="https://raw.github.com/pmuir/github-flavored-markdown/gh-pages/shared/css/documentation.css" rel="stylesheet"></link><link href="https://raw.github.com/github/github-flavored-markdown/gh-pages/shared/css/pygments.css" rel="stylesheet"></link></head><body><!--~ Do not edit this derived file! See jboss-portal-quickstarts/src/main/freemarker/jsf2-hello-world-portlet/README.html.ftl ~-->
+<!DOCTYPE html><html><head><title>README</title><link href="http://static.jboss.org/ffe/0/www/vendor/redhat/documentation.css" rel="stylesheet"></link><link href="http://static.jboss.org/ffe/0/www/vendor/redhat/pygments.css" rel="stylesheet"></link></head><body><!--~ Do not edit this derived file! See jboss-portal-quickstarts/src/main/freemarker/jsf2-hello-world-portlet/README.html.ftl ~-->
 
 <h1><a id="jsf2helloworldportlet-jsf2-hello-world-portlet" class="anchor" href="#jsf2helloworldportlet-jsf2-hello-world-portlet"><span class="anchor-icon"></span></a>jsf2-hello-world-portlet: JSF2 Hello World Portlet</h1>
 

--- a/jsf2-rf4-hello-world-portlet/README.html
+++ b/jsf2-rf4-hello-world-portlet/README.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html><head><title>README</title><link href="https://raw.github.com/pmuir/github-flavored-markdown/gh-pages/shared/css/documentation.css" rel="stylesheet"></link><link href="https://raw.github.com/github/github-flavored-markdown/gh-pages/shared/css/pygments.css" rel="stylesheet"></link></head><body><!--~ Do not edit this derived file! See jboss-portal-quickstarts/src/main/freemarker/jsf2-rf4-hello-world-portlet/README.html.ftl ~-->
+<!DOCTYPE html><html><head><title>README</title><link href="http://static.jboss.org/ffe/0/www/vendor/redhat/documentation.css" rel="stylesheet"></link><link href="http://static.jboss.org/ffe/0/www/vendor/redhat/pygments.css" rel="stylesheet"></link></head><body><!--~ Do not edit this derived file! See jboss-portal-quickstarts/src/main/freemarker/jsf2-rf4-hello-world-portlet/README.html.ftl ~-->
 
 <h1><a id="jsf2rf4helloworldportlet-jsf2rf4-hello-world-portlet" class="anchor" href="#jsf2rf4helloworldportlet-jsf2rf4-hello-world-portlet"><span class="anchor-icon"></span></a>jsf2-rf4-hello-world-portlet: JSF2+RF4 Hello World Portlet</h1>
 

--- a/navigation-api-portlet/README.html
+++ b/navigation-api-portlet/README.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html><head><title>README</title><link href="https://raw.github.com/pmuir/github-flavored-markdown/gh-pages/shared/css/documentation.css" rel="stylesheet"></link><link href="https://raw.github.com/github/github-flavored-markdown/gh-pages/shared/css/pygments.css" rel="stylesheet"></link></head><body><!--~ Do not edit this derived file! See jboss-portal-quickstarts/src/main/freemarker/navigation-api-portlet/README.html.ftl ~-->
+<!DOCTYPE html><html><head><title>README</title><link href="http://static.jboss.org/ffe/0/www/vendor/redhat/documentation.css" rel="stylesheet"></link><link href="http://static.jboss.org/ffe/0/www/vendor/redhat/pygments.css" rel="stylesheet"></link></head><body><!--~ Do not edit this derived file! See jboss-portal-quickstarts/src/main/freemarker/navigation-api-portlet/README.html.ftl ~-->
 
 <h1><a id="navigationapiportlet-navigation-api-portlet" class="anchor" href="#navigationapiportlet-navigation-api-portlet"><span class="anchor-icon"></span></a>navigation-api-portlet: Navigation API Portlet</h1>
 

--- a/page-composition-api-portlet/README.html
+++ b/page-composition-api-portlet/README.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html><head><title>README</title><link href="https://raw.github.com/pmuir/github-flavored-markdown/gh-pages/shared/css/documentation.css" rel="stylesheet"></link><link href="https://raw.github.com/github/github-flavored-markdown/gh-pages/shared/css/pygments.css" rel="stylesheet"></link></head><body><!--~ Do not edit this derived file! See jboss-portal-quickstarts/src/main/freemarker/page-composition-api-portlet/README.html.ftl ~-->
+<!DOCTYPE html><html><head><title>README</title><link href="http://static.jboss.org/ffe/0/www/vendor/redhat/documentation.css" rel="stylesheet"></link><link href="http://static.jboss.org/ffe/0/www/vendor/redhat/pygments.css" rel="stylesheet"></link></head><body><!--~ Do not edit this derived file! See jboss-portal-quickstarts/src/main/freemarker/page-composition-api-portlet/README.html.ftl ~-->
 
 <h1><a id="pagecompositionapiportlet-page-composition-api-portlet" class="anchor" href="#pagecompositionapiportlet-page-composition-api-portlet"><span class="anchor-icon"></span></a>page-composition-api-portlet: Page Composition API Portlet</h1>
 

--- a/portal-extension/README.html
+++ b/portal-extension/README.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html><head><title>README</title><link href="https://raw.github.com/pmuir/github-flavored-markdown/gh-pages/shared/css/documentation.css" rel="stylesheet"></link><link href="https://raw.github.com/github/github-flavored-markdown/gh-pages/shared/css/pygments.css" rel="stylesheet"></link></head><body><!--~ Do not edit this derived file! See jboss-portal-quickstarts/src/main/freemarker/portal-extension/README.html.ftl ~-->
+<!DOCTYPE html><html><head><title>README</title><link href="http://static.jboss.org/ffe/0/www/vendor/redhat/documentation.css" rel="stylesheet"></link><link href="http://static.jboss.org/ffe/0/www/vendor/redhat/pygments.css" rel="stylesheet"></link></head><body><!--~ Do not edit this derived file! See jboss-portal-quickstarts/src/main/freemarker/portal-extension/README.html.ftl ~-->
 
 <h1><a id="portalextension-portal-extension" class="anchor" href="#portalextension-portal-extension"><span class="anchor-icon"></span></a>portal-extension: Portal Extension</h1>
 

--- a/sample-portal/README.html
+++ b/sample-portal/README.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html><head><title>README</title><link href="https://raw.github.com/pmuir/github-flavored-markdown/gh-pages/shared/css/documentation.css" rel="stylesheet"></link><link href="https://raw.github.com/github/github-flavored-markdown/gh-pages/shared/css/pygments.css" rel="stylesheet"></link></head><body><!--~ Do not edit this derived file! See jboss-portal-quickstarts/src/main/freemarker/sample-portal/README.html.ftl ~-->
+<!DOCTYPE html><html><head><title>README</title><link href="http://static.jboss.org/ffe/0/www/vendor/redhat/documentation.css" rel="stylesheet"></link><link href="http://static.jboss.org/ffe/0/www/vendor/redhat/pygments.css" rel="stylesheet"></link></head><body><!--~ Do not edit this derived file! See jboss-portal-quickstarts/src/main/freemarker/sample-portal/README.html.ftl ~-->
 
 <h1><a id="sampleportal-sample-portal" class="anchor" href="#sampleportal-sample-portal"><span class="anchor-icon"></span></a>sample-portal: Sample Portal</h1>
 

--- a/simplest-hello-world-portlet/README.html
+++ b/simplest-hello-world-portlet/README.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html><head><title>README</title><link href="https://raw.github.com/pmuir/github-flavored-markdown/gh-pages/shared/css/documentation.css" rel="stylesheet"></link><link href="https://raw.github.com/github/github-flavored-markdown/gh-pages/shared/css/pygments.css" rel="stylesheet"></link></head><body><!--~ Do not edit this derived file! See jboss-portal-quickstarts/src/main/freemarker/simplest-hello-world-portlet/README.html.ftl ~-->
+<!DOCTYPE html><html><head><title>README</title><link href="http://static.jboss.org/ffe/0/www/vendor/redhat/documentation.css" rel="stylesheet"></link><link href="http://static.jboss.org/ffe/0/www/vendor/redhat/pygments.css" rel="stylesheet"></link></head><body><!--~ Do not edit this derived file! See jboss-portal-quickstarts/src/main/freemarker/simplest-hello-world-portlet/README.html.ftl ~-->
 
 <h1><a id="simplesthelloworldportlet-simplest-hello-world-portlet" class="anchor" href="#simplesthelloworldportlet-simplest-hello-world-portlet"><span class="anchor-icon"></span></a>simplest-hello-world-portlet: Simplest Hello World Portlet</h1>
 

--- a/social-portlets/README.html
+++ b/social-portlets/README.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html><head><title>README</title><link href="https://raw.github.com/pmuir/github-flavored-markdown/gh-pages/shared/css/documentation.css" rel="stylesheet"></link><link href="https://raw.github.com/github/github-flavored-markdown/gh-pages/shared/css/pygments.css" rel="stylesheet"></link></head><body><!--~ Do not edit this derived file! See jboss-portal-quickstarts/src/main/freemarker/social-portlets/README.html.ftl ~-->
+<!DOCTYPE html><html><head><title>README</title><link href="http://static.jboss.org/ffe/0/www/vendor/redhat/documentation.css" rel="stylesheet"></link><link href="http://static.jboss.org/ffe/0/www/vendor/redhat/pygments.css" rel="stylesheet"></link></head><body><!--~ Do not edit this derived file! See jboss-portal-quickstarts/src/main/freemarker/social-portlets/README.html.ftl ~-->
 
 <h1><a id="socialportlets-social-portlets" class="anchor" href="#socialportlets-social-portlets"><span class="anchor-icon"></span></a>social-portlets: Social Portlets</h1>
 


### PR DESCRIPTION
Stylesheets are no longer served up by GitHub. They were moved to jboss.org for a while, but disappeared when the site was revamped. They have now been added to a new location here: http://static.jboss.org/ffe/0/www/vendor/redhat/

I updated the JBoss EAP and WFK quickstart scripts, but am unclear how you are generating your HTML in this repository. If you do not want to merge this pull, feel free to steal what you need!
